### PR TITLE
(fix) add node_modules to .gcloudignore

### DIFF
--- a/EnvAM/.gcloudignore
+++ b/EnvAM/.gcloudignore
@@ -17,3 +17,5 @@
 __pycache__/
 # Ignored by the build system
 /setup.cfg
+
+**/node_modules


### PR DESCRIPTION
Node Modules makes project too large to deploy to GCP. Adding it to .gcloudignore.